### PR TITLE
Add spoiler functionality

### DIFF
--- a/commands/readspoiler.js
+++ b/commands/readspoiler.js
@@ -2,7 +2,10 @@ const Confax = require('../bot.js')
 const spoilerMsg = require('./spoiler.js')
 
 Confax.registerCommand('readspoiler', 'default', (message, bot) => {
-  message.react("👍")
   let combinedMessage = '**Originally posted by** ' + spoilerMsg.spoilerMsgAuthor + '\n**Content:** ' + spoilerMsg.spoilerMsgContent
-  message.author.send(combinedMessage)
+  message.author.send(combinedMessage).then(() => {message.react("👍")})
+    .catch((error) => {
+      message.reply("Please enable DMs to receive the message!")
+      message.react("😞")
+    })
 }, ['tellmethesecret', 'sendmemsg'], 'Read latest spoiler (content will be sent via DMs)', '')

--- a/commands/readspoiler.js
+++ b/commands/readspoiler.js
@@ -3,12 +3,12 @@ const spoilerMsg = require('./spoiler.js')
 
 Confax.registerCommand('readspoiler', 'default', (message, bot) => {
   let combinedMessage = '**Originally posted by** ' + spoilerMsg.spoilerMsgAuthor + '\n**Content:** ' + spoilerMsg.spoilerMsgContent
-  if(spoilerMsg.spoilerMsgAttachment !== "none"){
-    combinedMessage += "\n**Attachment:** " + spoilerMsg.spoilerMsgAttachment
+  if(spoilerMsg.spoilerMsgAttachment !== 'none'){
+    combinedMessage += '\n**Attachment:** ' + spoilerMsg.spoilerMsgAttachment
   }
   message.author.send(combinedMessage).then(() => {message.react("👍")})
     .catch((error) => {
-      message.reply("Please enable DMs to receive the message!")
-      message.react("😞")
+      message.reply('Please enable DMs to receive the message!')
+      message.react('😞')
     })
 }, ['tellmethesecret', 'sendmemsg'], 'Read latest spoiler (content will be sent via DMs)', '')

--- a/commands/readspoiler.js
+++ b/commands/readspoiler.js
@@ -1,0 +1,8 @@
+const Confax = require('../bot.js')
+const spoilerMsg = require('./spoiler.js')
+
+Confax.registerCommand('readspoiler', 'default', (message, bot) => {
+  message.react("👍")
+  let combinedMessage = '**Originally posted by** ' + spoilerMsg.spoilerMsgAuthor + '\n**Content:** ' + spoilerMsg.spoilerMsgContent
+  message.author.send(combinedMessage)
+}, ['tellmethesecret', 'sendmemsg'], 'Read latest spoiler (content will be sent via DMs)', '')

--- a/commands/readspoiler.js
+++ b/commands/readspoiler.js
@@ -3,6 +3,9 @@ const spoilerMsg = require('./spoiler.js')
 
 Confax.registerCommand('readspoiler', 'default', (message, bot) => {
   let combinedMessage = '**Originally posted by** ' + spoilerMsg.spoilerMsgAuthor + '\n**Content:** ' + spoilerMsg.spoilerMsgContent
+  if(spoilerMsg.spoilerMsgAttachment !== "none"){
+    combinedMessage += "\n**Attachment:** " + spoilerMsg.spoilerMsgAttachment
+  }
   message.author.send(combinedMessage).then(() => {message.react("👍")})
     .catch((error) => {
       message.reply("Please enable DMs to receive the message!")

--- a/commands/spoiler.js
+++ b/commands/spoiler.js
@@ -2,9 +2,9 @@ const Confax = require('../bot.js')
 
 module.exports = 
   spoilerMsg = {
-    spoilerMsgContent: "*PSST* long form of bike is bikael",
-    spoilerMsgAuthor: "Yours truly",
-    spoilerMsgAttachment: "none"
+    spoilerMsgContent: '*PSST* long form of bike is bikael',
+    spoilerMsgAuthor: 'Yours truly',
+    spoilerMsgAttachment: 'none'
 }
 
 Confax.registerCommand('spoiler', 'default', (message, bot) => {

--- a/commands/spoiler.js
+++ b/commands/spoiler.js
@@ -1,0 +1,14 @@
+const Confax = require('../bot.js')
+
+module.exports = 
+  spoilerMsg = {
+    spoilerMsgContent: "",
+    spoilerMsgAuthor: ""
+}
+
+Confax.registerCommand('spoiler', 'default', (message, bot) => {
+  message.delete()
+  if (message.content === '') return "Do you want me not to spoil silence? :thinking: The message can't be empty!"
+  spoilerMsg.spoilerMsgAuthor = message.author.tag
+  spoilerMsg.spoilerMsgContent = message.content
+}, ['hidemsg', 'spoileralert'], 'Hide specific message content from all users. Message can be read with !readspoiler command', '[message]')

--- a/commands/spoiler.js
+++ b/commands/spoiler.js
@@ -3,13 +3,25 @@ const Confax = require('../bot.js')
 module.exports = 
   spoilerMsg = {
     spoilerMsgContent: "*PSST* long form of bike is bikael",
-    spoilerMsgAuthor: "Yours truly"
+    spoilerMsgAuthor: "Yours truly",
+    spoilerMsgAttachment: "none"
 }
 
 Confax.registerCommand('spoiler', 'default', (message, bot) => {
   message.delete()
-  if (message.content === '') return "Do you want me not to spoil silence? :thinking: The message can't be empty!"
-  spoilerMsg.spoilerMsgAuthor = message.author.tag
-  spoilerMsg.spoilerMsgContent = message.content
-  message.reply("oof, lets not spoil this to everyone ;)")
+  if (message.content !== '' || message.attachments.size > 0){
+    spoilerMsg.spoilerMsgAuthor = message.author.tag
+    spoilerMsg.spoilerMsgContent = message.content
+    if(message.attachments.size > 0){
+      // Only first attachment will be added to the spoiler
+      spoilerMsg.spoilerMsgAttachment = message.attachments.array()[0].url
+    }
+    else{
+      spoilerMsg.spoilerMsgAttachment = 'none'
+    }
+    message.reply('oof, lets not spoil this to everyone ;)')
+  }
+  else {
+    return "Do you want me not to spoil silence? :thinking: The message can't be empty!"
+  }
 }, ['hidemsg', 'spoileralert'], 'Hide specific message content from all users. Message can be read with !readspoiler command', '[message]')

--- a/commands/spoiler.js
+++ b/commands/spoiler.js
@@ -11,4 +11,5 @@ Confax.registerCommand('spoiler', 'default', (message, bot) => {
   if (message.content === '') return "Do you want me not to spoil silence? :thinking: The message can't be empty!"
   spoilerMsg.spoilerMsgAuthor = message.author.tag
   spoilerMsg.spoilerMsgContent = message.content
+  message.reply("oof, lets not spoil this to everyone ;)")
 }, ['hidemsg', 'spoileralert'], 'Hide specific message content from all users. Message can be read with !readspoiler command', '[message]')

--- a/commands/spoiler.js
+++ b/commands/spoiler.js
@@ -8,7 +8,6 @@ module.exports =
 }
 
 Confax.registerCommand('spoiler', 'default', (message, bot) => {
-  message.delete()
   if (message.content !== '' || message.attachments.size > 0){
     spoilerMsg.spoilerMsgAuthor = message.author.tag
     spoilerMsg.spoilerMsgContent = message.content
@@ -22,6 +21,21 @@ Confax.registerCommand('spoiler', 'default', (message, bot) => {
     message.reply('oof, lets not spoil this to everyone ;)')
   }
   else {
+    message.delete()
     return "Do you want me not to spoil silence? :thinking: The message can't be empty!"
   }
+  SendMessageToAuthor(message.author)
+  setTimeout(() => message.delete(), 1000)
 }, ['hidemsg', 'spoileralert'], 'Hide specific message content from all users. Message can be read with !readspoiler command', '[message]')
+
+
+function SendMessageToAuthor(author){
+  let combinedMessage = '**Here is the last spoiler u saved:** ' + spoilerMsg.spoilerMsgContent
+  if(spoilerMsg.spoilerMsgAttachment !== 'none'){
+    combinedMessage += '\n**Attachment:** ' + spoilerMsg.spoilerMsgAttachment
+  }
+  author.send(combinedMessage)
+    .catch((error) => {
+      message.reply('Please enable DMs to receive the message!')
+    })
+}

--- a/commands/spoiler.js
+++ b/commands/spoiler.js
@@ -2,8 +2,8 @@ const Confax = require('../bot.js')
 
 module.exports = 
   spoilerMsg = {
-    spoilerMsgContent: "",
-    spoilerMsgAuthor: ""
+    spoilerMsgContent: "*PSST* long form of bike is bikael",
+    spoilerMsgAuthor: "Yours truly"
 }
 
 Confax.registerCommand('spoiler', 'default', (message, bot) => {


### PR DESCRIPTION
PR contains **two** commands: 
`!spoiler` - hides message from users
`!readspoiler` - sends previously saved spoiler to user's DM 