### PR TITLE
Fix advancedhelp command

### DIFF
--- a/commands/advancedhelp.js
+++ b/commands/advancedhelp.js
@@ -1,9 +1,10 @@
-const Discord = require('discord.js')
 const Confax = require('../bot.js')
 const config = require('../config.json')
 
 Confax.registerCommand('advancedhelp', 'default', (message, bot) => {
-  let helpMsg = ''
+  let helpMsg = '**Advanced Help**\n\n' +
+  'All commands are prefixed with: `' + config.prefix + '`\n\n'
+
   let commands = Confax.commands
 
   for (let loopCmdType in commands) {
@@ -30,11 +31,13 @@ Confax.registerCommand('advancedhelp', 'default', (message, bot) => {
       }
 
       helpMsg += '\n```'
+      if (helpMsg.length >= 1900) {
+        message.author.send(helpMsg)
+        helpMsg = ''
+      }
     }
   }
 
-  message.author.send('**Advanced Help**\n\n' +
-  'All commands are prefixed with: `' + config.prefix + '` and suffixed with: `' + config.suffix + '`\n\n' +
-  helpMsg, { split: true })
+  message.author.send(helpMsg, { split: true })
   return 'I sent you the advanced help list as a DM!'
 }, [], 'List advanced information about every registered command', '[]')


### PR DESCRIPTION
Longer command lists would cause a message to be split at an arbitrary spot, resulting in broken formatting of the resultant message.