### PR TITLE
Add groundwork for server-specific config files.

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,7 +1,6 @@
 const Discord = require('discord.js')
 const bot = new Discord.Client()
 const fs = require('fs')
-const yaml = require('js-yaml')
 const config = require('./config')
 const http = require('http')
 const dotenv = require('dotenv')
@@ -23,7 +22,7 @@ var registerCommand = function (name, type, callback, aliases, description, usag
 }
 
 var loadScript = (path, reload) => {
-  var req = require(path)
+  // var req = require(path)
   if (reload) {
     console.log('Reloaded script at ' + path)
   } else {
@@ -32,16 +31,27 @@ var loadScript = (path, reload) => {
 }
 
 function changeConfig (guildID, callback) {
-  var path = './confaxfiles/' + guildID + '.yml'
-  var data = yaml.safeLoad(fs.readFileSync(path))
+  var path = './guilds/' + guildID + '.json'
+  var data = JSON.parse(fs.readFileSync(path))
   callback()
-  fs.writeFileSync(path, yaml.safeDump(data))
+  fs.writeFileSync(path, JSON.stringify(data, null, 2))
   console.log('Edited config in ' + path)
 }
 
+function getConfig (guildID) {
+  var path = './guilds/' + guildID + '.json'
+  var data = JSON.parse(fs.readFileSync(path))
+  try { return data } catch (error) { console.log('An error occured: ' + error.stack) }
+}
+
+function setConfig (guildID, config) {
+  var path = './guilds/' + guildID + '.json'
+  fs.writeFileSync(path, JSON.stringify(config, null, 2))
+}
+
 function getConfigValue (guildID, name) {
-  var path = './confaxfiles/' + guildID + '.yml'
-  var data = yaml.safeLoad(fs.readFileSync(path))
+  var path = './guilds/' + guildID + '.json'
+  var data = JSON.parse(fs.readFileSync(path))
   try { return data[name] } catch (error) { console.log('An error occured: ' + error.stack) }
 }
 
@@ -49,6 +59,8 @@ exports.registerCommand = registerCommand
 exports.loadScript = loadScript
 exports.changeConfig = changeConfig
 exports.getConfigValue = getConfigValue
+exports.getConfig = getConfig
+exports.setConfig = setConfig
 
 var commands = fs.readdirSync('./commands/')
 commands.forEach(script => {

--- a/bot.js
+++ b/bot.js
@@ -22,7 +22,7 @@ var registerCommand = function (name, type, callback, aliases, description, usag
 }
 
 var loadScript = (path, reload) => {
-  // var req = require(path)
+  require(path)
   if (reload) {
     console.log('Reloaded script at ' + path)
   } else {

--- a/modules/serverconfigs.js
+++ b/modules/serverconfigs.js
@@ -1,16 +1,16 @@
-const Discord = require('discord.js')
 const Confax = require('../bot.js')
+const fs = require('fs')
 
 Confax.bot.on('guildCreate', (guild) => {
-  var guildID = guild.id
-  var path = './confaxfiles/' + guildID + '.yml'
-  fs.writeFileSync(path, defaultConfig)
+  let guildID = guild.id
+  let path = './guilds/' + guildID + '.json'
+  fs.writeFileSync(path, JSON.stringify(Confax.config, null, 2))
   guild.owner.send('Thank you for adding Confax to your guild named **' + guild.name + '**.\n\nConfax will use the default configuration.')
 })
 
 Confax.bot.on('guildDelete', (guild) => {
-  var guildID = guild.id
-  var path = './confaxfiles/' + guildID + '.yml'
+  let guildID = guild.id
+  let path = './guilds/' + guildID + '.json'
   try { fs.unlinkSync(path) } catch (error) { console.log('An error occured: ' + error.stack) }
   console.log('Deleted guild config file for ' + guild + '(' + path + ')')
 })


### PR DESCRIPTION
This PR creates the ground work for server-specific config files. This feature is not utilized in this PR, but has all the necessary tools to do so.

There are two function within bot.js; one to load a config file based on guild id and one to set the config file for when changes are made.

Server-specific configs will be created when the bot joins a server, and are stored in `Confax/guilds/`

Each command that uses a config will need to call `Confax.getConfig(guildID)` with the appropriate guild id.
